### PR TITLE
refactor: improve Rumdl binary installer and asset selection

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,8 +1,8 @@
+authors = ["Inflation <me@kosmopho.dev>", "anhkhoakz <anhkhoakz.dev>"]
 id = "rumdl"
 name = "Rumdl Markdown Linter"
 version = "0.0.1"
 schema_version = 1
-authors = ["Inflation <me@kosmopho.dev>", "ankhoakz"]
 description = "A high-performance Markdown linter, written in Rust"
 repository = "https://github.com/anhkhoakz/zed-rumdl"
 

--- a/extension.toml
+++ b/extension.toml
@@ -2,9 +2,9 @@ id = "rumdl"
 name = "Rumdl Markdown Linter"
 version = "0.0.1"
 schema_version = 1
-authors = ["Inflation <me@kosmopho.dev>"]
+authors = ["Inflation <me@kosmopho.dev>", "ankhoakz"]
 description = "A high-performance Markdown linter, written in Rust"
-repository = "https://github.com/inflation/zed-rumdl"
+repository = "https://github.com/anhkhoakz/zed-rumdl"
 
 [language_servers.rumdl]
 name = "Rumdl"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ impl Rumdl {
         release: &'a zed::GithubRelease,
         arch_name: &str,
         file_ext: &str,
-        gnu_error: String,
+        gnu_error: &str,
     ) -> zed::Result<&'a zed::GithubReleaseAsset> {
         Self::find_release_asset(release, arch_name, "unknown-linux-musl", file_ext)
             .map_err(|musl_err| format!("{musl_err}; gnu attempt failed: {gnu_error}"))
@@ -98,7 +98,7 @@ impl Rumdl {
         let gnu_error = gnu_asset
             .err()
             .unwrap_or_else(|| "unknown linux gnu asset failure".into());
-        Self::find_linux_musl_asset(release, arch_name, file_ext, gnu_error)
+        Self::find_linux_musl_asset(release, arch_name, file_ext, &gnu_error)
     }
 
     fn build_versioned_binary_path(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-use std::{fs, path::PathBuf};
+use std::fs;
+use std::path::{Path, PathBuf};
 
 use zed_extension_api::{
     self as zed, Extension, LanguageServerId, Worktree, register_extension, settings::LspSettings,
@@ -11,14 +12,187 @@ pub struct Rumdl {
 #[derive(Clone)]
 struct RumdlBinary {
     path: PathBuf,
-    env: Option<Vec<(String, String)>>,
+    env: Vec<(String, String)>,
 }
 
 const NAME: &str = "rumdl";
+const NAME_PREFIX: &str = "rumdl-";
+const RUMDL_GITHUB_REPO: &str = "rvben/rumdl";
 
 impl Rumdl {
-    fn new() -> Self {
-        Rumdl { binary_cache: None }
+    const fn new() -> Self {
+        Self { binary_cache: None }
+    }
+
+    fn arch_name(arch: zed::Architecture) -> zed::Result<&'static str> {
+        if arch == zed::Architecture::X8664 {
+            return Ok("x86_64");
+        }
+
+        if arch == zed::Architecture::Aarch64 {
+            return Ok("aarch64");
+        }
+
+        Err(format!("Unsupported architecture: {arch:?}"))
+    }
+
+    fn os_asset_info(platform: zed::Os) -> (&'static str, &'static str) {
+        if platform == zed::Os::Mac {
+            return ("apple-darwin", "tar.gz");
+        }
+
+        if platform == zed::Os::Linux {
+            return ("unknown-linux-gnu", "tar.gz");
+        }
+
+        ("pc-windows-msvc", "zip")
+    }
+
+    fn find_release_asset<'a>(
+        release: &'a zed::GithubRelease,
+        arch_name: &str,
+        os_str: &str,
+        file_ext: &str,
+    ) -> zed::Result<&'a zed::GithubReleaseAsset> {
+        let asset_name = format!("{arch_name}-{os_str}.{file_ext}");
+        let asset = release
+            .assets
+            .iter()
+            .find(|a| a.name.ends_with(&asset_name));
+
+        let Some(asset) = asset else {
+            return Err(format!(
+                "No compatible Rumdl binary found for {arch_name}-{os_str}"
+            ));
+        };
+
+        Ok(asset)
+    }
+
+    fn find_linux_musl_asset<'a>(
+        release: &'a zed::GithubRelease,
+        arch_name: &str,
+        file_ext: &str,
+        gnu_error: String,
+    ) -> zed::Result<&'a zed::GithubReleaseAsset> {
+        Self::find_release_asset(release, arch_name, "unknown-linux-musl", file_ext)
+            .map_err(|musl_err| format!("{musl_err}; gnu attempt failed: {gnu_error}"))
+    }
+
+    fn find_release_asset_for_platform<'a>(
+        release: &'a zed::GithubRelease,
+        arch_name: &str,
+        platform: zed::Os,
+    ) -> zed::Result<&'a zed::GithubReleaseAsset> {
+        let (os_str, file_ext) = Self::os_asset_info(platform);
+        let gnu_asset = Self::find_release_asset(release, arch_name, os_str, file_ext);
+
+        if platform != zed::Os::Linux {
+            return gnu_asset;
+        }
+
+        if let Ok(asset) = gnu_asset {
+            return Ok(asset);
+        }
+
+        let gnu_error = gnu_asset
+            .err()
+            .unwrap_or_else(|| "unknown linux gnu asset failure".into());
+        Self::find_linux_musl_asset(release, arch_name, file_ext, gnu_error)
+    }
+
+    fn build_versioned_binary_path(
+        release_version: &str,
+        platform: zed::Os,
+    ) -> zed::Result<(String, PathBuf)> {
+        if release_version.contains('/') {
+            return Err("Invalid release version: contains '/'".into());
+        }
+
+        if release_version.contains('\\') {
+            return Err("Invalid release version: contains '\\\\'".into());
+        }
+
+        let version_dir = format!("{NAME}-{release_version}");
+        let mut binary_path = PathBuf::from(&version_dir).join(NAME);
+
+        if platform == zed::Os::Windows {
+            binary_path.set_extension("exe");
+        }
+
+        Ok((version_dir, binary_path))
+    }
+
+    fn download_binary(
+        language_server_id: &LanguageServerId,
+        version_dir: &str,
+        binary_path: &Path,
+        asset: &zed::GithubReleaseAsset,
+        platform: zed::Os,
+    ) -> zed::Result<()> {
+        zed::set_language_server_installation_status(
+            language_server_id,
+            &zed::LanguageServerInstallationStatus::Downloading,
+        );
+
+        let file_type = match platform {
+            zed::Os::Windows => zed::DownloadedFileType::Zip,
+            _ => zed::DownloadedFileType::GzipTar,
+        };
+
+        zed::download_file(&asset.download_url, version_dir, file_type)
+            .map_err(|e| format!("Failed to download Rumdl binary: {e}"))?;
+
+        let binary_path = binary_path.to_str().ok_or("Invalid binary path")?;
+        zed::make_file_executable(binary_path)
+            .map_err(|e| format!("Failed to make binary executable: {e}"))?;
+
+        Ok(())
+    }
+
+    fn download_binary_or_cleanup(
+        language_server_id: &LanguageServerId,
+        version_dir: &str,
+        binary_path: &Path,
+        asset: &zed::GithubReleaseAsset,
+        platform: zed::Os,
+    ) -> zed::Result<()> {
+        let download_result = Self::download_binary(
+            language_server_id,
+            version_dir,
+            binary_path,
+            asset,
+            platform,
+        );
+        if download_result.is_ok() {
+            return Ok(());
+        }
+
+        // Best-effort cleanup to avoid leaving partial installs behind.
+        fs::remove_dir_all(version_dir).ok();
+        download_result
+    }
+
+    fn cleanup_other_versions(current_version_dir: &str) {
+        let Ok(entries) = fs::read_dir(".") else {
+            return;
+        };
+
+        for entry in entries.flatten() {
+            let Ok(name) = entry.file_name().into_string() else {
+                continue;
+            };
+
+            if name == current_version_dir {
+                continue;
+            }
+
+            if !name.starts_with(NAME_PREFIX) {
+                continue;
+            }
+
+            fs::remove_dir_all(entry.path()).ok();
+        }
     }
 
     fn get_binary(
@@ -29,7 +203,7 @@ impl Rumdl {
         if let Some(path) = worktree.which(NAME) {
             return Ok(RumdlBinary {
                 path: PathBuf::from(path),
-                env: Some(worktree.shell_env()),
+                env: worktree.shell_env(),
             });
         }
 
@@ -38,7 +212,7 @@ impl Rumdl {
         {
             return Ok(RumdlBinary {
                 path: path.clone(),
-                env: None,
+                env: Vec::new(),
             });
         }
 
@@ -55,7 +229,7 @@ impl Rumdl {
         );
 
         let release = zed::latest_github_release(
-            "rvben/rumdl",
+            RUMDL_GITHUB_REPO,
             zed::GithubReleaseOptions {
                 require_assets: true,
                 pre_release: false,
@@ -64,76 +238,32 @@ impl Rumdl {
         .map_err(|e| format!("Failed to fetch latest release: {e}"))?;
 
         let (platform, arch) = zed::current_platform();
-        let arch_name = match arch {
-            zed::Architecture::X8664 => "x86_64",
-            zed::Architecture::Aarch64 => "aarch64",
-            a => return Err(format!("Unsupported architecture: {a:?}")),
-        };
+        let arch_name = Self::arch_name(arch)?;
+        let asset = Self::find_release_asset_for_platform(&release, arch_name, platform)?;
+        let (version_dir, binary_path) =
+            Self::build_versioned_binary_path(&release.version, platform)?;
 
-        let (os_str, file_ext) = match platform {
-            zed::Os::Mac => ("apple-darwin", "tar.gz"),
-            zed::Os::Linux => ("unknown-linux-gnu", "tar.gz"),
-            zed::Os::Windows => ("pc-windows-msvc", "zip"),
-        };
-
-        let asset_name = format!("{arch_name}-{os_str}.{file_ext}");
-        let asset = release
-            .assets
-            .iter()
-            .find(|a| a.name.ends_with(&asset_name))
-            .ok_or_else(|| format!("No compatible Rumdl binary found for {arch_name}-{os_str}"))?;
-
-        let version_dir = format!("{NAME}-{}", release.version);
-        let mut binary_path = PathBuf::from(&version_dir).join(NAME);
-
-        if platform == zed::Os::Windows {
-            binary_path.set_extension("exe");
+        if binary_path.exists() {
+            self.binary_cache = Some(binary_path.clone());
+            return Ok(RumdlBinary {
+                path: binary_path,
+                env: Vec::new(),
+            });
         }
 
-        if !binary_path.exists() {
-            zed::set_language_server_installation_status(
-                language_server_id,
-                &zed::LanguageServerInstallationStatus::Downloading,
-            );
-
-            let download_result = (|| -> zed::Result<()> {
-                zed::download_file(
-                    &asset.download_url,
-                    &version_dir,
-                    if platform == zed::Os::Windows {
-                        zed::DownloadedFileType::Zip
-                    } else {
-                        zed::DownloadedFileType::GzipTar
-                    },
-                )
-                .map_err(|e| format!("Failed to download Rumdl binary: {e}"))?;
-
-                zed::make_file_executable(binary_path.to_str().ok_or("Invalid binary path")?)
-                    .map_err(|e| format!("Failed to make binary executable: {e}"))?;
-
-                Ok(())
-            })();
-
-            if let Err(e) = download_result {
-                fs::remove_dir_all(&version_dir).ok();
-                return Err(e);
-            }
-
-            if let Ok(entries) = fs::read_dir(".") {
-                for entry in entries.flatten() {
-                    if let Ok(name) = entry.file_name().into_string()
-                        && name != version_dir
-                    {
-                        fs::remove_dir_all(entry.path()).ok();
-                    }
-                }
-            }
-        }
+        Self::download_binary_or_cleanup(
+            language_server_id,
+            &version_dir,
+            &binary_path,
+            asset,
+            platform,
+        )?;
+        Self::cleanup_other_versions(&version_dir);
 
         self.binary_cache = Some(binary_path.clone());
         Ok(RumdlBinary {
             path: binary_path,
-            env: None,
+            env: Vec::new(),
         })
     }
 }
@@ -156,7 +286,7 @@ impl Extension for Rumdl {
                 .ok_or("Failed to convert binary path to string")?
                 .into(),
             args: vec!["server".into()],
-            env: binary.env.unwrap_or_default(),
+            env: binary.env,
         })
     }
 
@@ -167,7 +297,7 @@ impl Extension for Rumdl {
     ) -> zed::Result<Option<zed::serde_json::Value>> {
         let settings = LspSettings::for_worktree(server_id.as_ref(), worktree)
             .ok()
-            .and_then(|lsp_settings| lsp_settings.settings.clone());
+            .and_then(|lsp_settings| lsp_settings.settings);
         Ok(settings)
     }
 }


### PR DESCRIPTION
## Changes

Refactors the Rumdl binary installation pipeline to improve platform compatibility, reliability, and maintainability.  
Also updates extension metadata and repository ownership.

## Behavior Impact

- Binary installation is more resilient across macOS, Linux (gnu/musl), and Windows.
- Prevents accumulation of old binary versions on disk.
- No breaking changes to public extension behavior.

## Motivation

The previous installer logic was monolithic and brittle across platforms.  
This refactor improves correctness, debuggability, and long-term maintainability while preserving existing behavior.