### PR TITLE
feat: support a user-configured rumdl binary path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,28 @@ Zed extension for the
 1. [Open the Extension Gallery](https://zed.dev/docs/extensions/installing-extensions)
 2. Search for `Rumdl` in the Gallery
 3. Click "Install"!
+
+## Configuration
+
+You do not need to install `rumdl` separately. If it is not already on your
+`PATH`, the extension downloads a release binary automatically and keeps it up
+to date. To use a specific binary instead, set a path in your Zed settings:
+
+```json
+{
+  "lsp": {
+    "rumdl": {
+      "binary": {
+        "path": "/path/to/rumdl"
+      }
+    }
+  }
+}
+```
+
+Binary resolution order:
+
+1. A configured `binary.path` (if set)
+2. `rumdl` found on your `PATH`
+3. Otherwise, a release binary downloaded automatically from GitHub
+   (no manual install needed)

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "rumdl"
 name = "Rumdl Markdown Linter"
-version = "0.0.1"
+version = "0.0.2"
 schema_version = 1
 authors = ["Inflation <me@kosmopho.dev>"]
 description = "A high-performance Markdown linter, written in Rust"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,19 @@ impl Rumdl {
         language_server_id: &LanguageServerId,
         worktree: &Worktree,
     ) -> zed::Result<RumdlBinary> {
+        // A user-configured binary path takes precedence over PATH and downloads.
+        if let Some(path) = LspSettings::for_worktree(language_server_id.as_ref(), worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.binary)
+            .and_then(|binary| binary.path)
+            .filter(|path| !path.is_empty())
+        {
+            return Ok(RumdlBinary {
+                path: PathBuf::from(path),
+                env: Some(worktree.shell_env()),
+            });
+        }
+
         if let Some(path) = worktree.which(NAME) {
             return Ok(RumdlBinary {
                 path: PathBuf::from(path),


### PR DESCRIPTION
This adds support for a user-configured binary path, so the extension can point at a specific `rumdl` (a project-pinned build, or an install that isn't on `PATH`):

```json
"lsp": { "rumdl": { "binary": { "path": "/path/to/rumdl" } } }
```

Resolution order becomes: configured `binary.path` → `rumdl` on `PATH` → download from GitHub releases (unchanged).

The README now also documents that default behavior, which should clear up the confusion in #2. As a side benefit, pointing at a local binary lets users with flaky GitHub connectivity bypass the auto-download entirely, a partial workaround for #4 (though not a real fix for the startup-blocking behavior there).
